### PR TITLE
Deliver methods moved to after_commit hooks due to notification transact...

### DIFF
--- a/gemfiles/rails40.gemfile.lock
+++ b/gemfiles/rails40.gemfile.lock
@@ -155,6 +155,8 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
+    test_after_commit (0.4.0)
+      activerecord (>= 3.2)
     thor (0.19.1)
     thread_safe (0.3.3)
     tilt (1.4.1)
@@ -185,5 +187,6 @@ DEPENDENCIES
   rspec-rails
   rspec-sidekiq
   sidekiq
+  test_after_commit
   turbolinks
   urbanairship

--- a/notify_user.gemspec
+++ b/notify_user.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "factory_girl_rails"
   s.add_development_dependency "capybara"
   s.add_development_dependency "awesome_print"
+  s.add_development_dependency "test_after_commit"
 
   s.test_files = Dir["spec/**/*"]
 end


### PR DESCRIPTION
...ions not nessecarily being commited by the time the sidekiq runs it's scheduled job