### PR TITLE
Replacing double escaped newlines with a literal newline character.

### DIFF
--- a/app/models/notify_user/houston.rb
+++ b/app/models/notify_user/houston.rb
@@ -36,8 +36,11 @@ module NotifyUser
     def setup_options
       space_allowance = PAYLOAD_LIMIT - used_space
 
+      mobile_message = @notification.mobile_message(space_allowance)
+      mobile_message.gsub!('\n', "\n")
+
       push_options = {
-        alert: @notification.mobile_message(space_allowance),
+        alert: mobile_message,
         badge: @notification.count_for_target,
         category: @notification.params[:category] || @notification.type,
         custom_data: @notification.params,

--- a/lib/notify_user/version.rb
+++ b/lib/notify_user/version.rb
@@ -1,3 +1,3 @@
 module NotifyUser
-  VERSION = "0.0.29"
+  VERSION = "0.0.30"
 end


### PR DESCRIPTION
Allow push notifications to have line breaks in them.