### PR TITLE
Fix/array conversion

### DIFF
--- a/app/models/notify_user/houston.rb
+++ b/app/models/notify_user/houston.rb
@@ -21,7 +21,7 @@ module NotifyUser
 
       device_method = @options[:device_method] || :devices
       begin
-        @devices = @notification.target.send(device_method)
+        @devices = @notification.target.send(device_method).to_a
       rescue
         Rails.logger.info "Notification target, #{@notification.target.class}, does not respond to the method, #{device_method}."
       end

--- a/lib/notify_user/version.rb
+++ b/lib/notify_user/version.rb
@@ -1,3 +1,3 @@
 module NotifyUser
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
Currently ending up with a collection proxy when this line is run, but because we're using `slice!` during error handling to clean out the assumed-sent notifications, our collection needs to be an array.