### PR TITLE
Fix/rearrange gateway check

### DIFF
--- a/app/models/notify_user/apn_connection.rb
+++ b/app/models/notify_user/apn_connection.rb
@@ -8,15 +8,17 @@ module NotifyUser
     end
 
     def setup
-      @uri, @certificate = if Rails.env.production? || apn_environment == :production
-        [
-          ::Houston::APPLE_PRODUCTION_GATEWAY_URI,
-          File.read("#{Rails.root}/config/keys/production_push.pem")
-        ]
-      else
+      @uri, @certificate = if Rails.env.development? || apn_environment == :development
+        Rails.logger.info "Using development gateway. Rails env: #{Rails.env}, APN_ENVIRONMENT: #{apn_environment}"
         [
           ::Houston::APPLE_DEVELOPMENT_GATEWAY_URI,
           File.read("#{Rails.root}/config/keys/development_push.pem")
+        ]
+      else
+        Rails.logger.info "Using production gateway. Rails env: #{Rails.env}, APN_ENVIRONMENT: #{apn_environment}"
+        [
+          ::Houston::APPLE_PRODUCTION_GATEWAY_URI,
+          File.read("#{Rails.root}/config/keys/production_push.pem")
         ]
       end
 

--- a/lib/notify_user/version.rb
+++ b/lib/notify_user/version.rb
@@ -1,3 +1,3 @@
 module NotifyUser
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
Instead of checking for production, and defaulting to development; for development and default to production.

@dawilster, reasoning for the change is in the first commit.