### PR TITLE
Feature/aggregate intervals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ log/*.log
 pkg/
 spec/dummy
 .DS_Store
+.ruby-version

--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ Unsubscribe link helper - add this to your views/notify_user/layouts/action_mail
 <% end %>
 ```
 
+##Upgrade v0.1.4 to v0.2
+Run aggregate_interval generator which generates the migrations to add a sent_time field to notifications
+```
+rails generate notify_user:aggr_interval
+rake db:migrate
+```
+
 ##Upgrading to JSON params data type
 Run json_update generator which generates the migrations to change the params datatype to json as well as convert the current data to json
 ```

--- a/app/controllers/notify_user/base_notifications_controller.rb
+++ b/app/controllers/notify_user/base_notifications_controller.rb
@@ -3,7 +3,7 @@ class NotifyUser::BaseNotificationsController < ApplicationController
   before_filter :authenticate!, :except => [:unauth_unsubscribe]
 
   def index
-    collection                                     
+    collection
     respond_to_method
   end
 
@@ -34,7 +34,7 @@ class NotifyUser::BaseNotificationsController < ApplicationController
   def mark_all
     @notifications = NotifyUser::BaseNotification.for_target(@user).where('state IN (?)', ["pending","sent"])
     @notifications.update_all(state: :read)
-    redirect_to notify_user_notifications_path  
+    redirect_to notify_user_notifications_path
   end
 
   def notifications_count
@@ -42,7 +42,7 @@ class NotifyUser::BaseNotificationsController < ApplicationController
     render json: {:count => @notifications.count}
   end
 
-  #get 
+  #get
   def read
     @notification = NotifyUser::BaseNotification.for_target(@user).where('id = ?', params[:id]).first
     unless @notification.read?
@@ -59,7 +59,7 @@ class NotifyUser::BaseNotificationsController < ApplicationController
   def unsubscribe
     if params[:type]
       unsubscribe_from(params[:type])
-      redirect_to notify_user_notifications_unsubscribe_path  
+      redirect_to notify_user_notifications_unsubscribe_path
     end
     @types = build_notification_types
     @unsubscribale_types = NotifyUser.unsubscribable_notifications
@@ -82,14 +82,14 @@ class NotifyUser::BaseNotificationsController < ApplicationController
           NotifyUser::Unsubscribe.unsubscribe(@user,type[:type])
         else
           if unsubscribe.empty?
-            #if unsubscribe doesn't exist create it 
+            #if unsubscribe doesn't exist create it
             unsubscribe = NotifyUser::Unsubscribe.create(target: @user, type: type[:type])
           end
         end
       end
       flash[:message] = "Successfully updated your notifcation settings"
-    end  
-    redirect_to notify_user_notifications_unsubscribe_path  
+    end
+    redirect_to notify_user_notifications_unsubscribe_path
   end
 
   def update_subscriptions(types)
@@ -97,13 +97,13 @@ class NotifyUser::BaseNotificationsController < ApplicationController
       unsubscribe = NotifyUser::Unsubscribe.has_unsubscribed_from(@user, type[:type])
       if type[:status] == '0'
         if unsubscribe.empty?
-          #if unsubscribe doesn't exist create it 
+          #if unsubscribe doesn't exist create it
           unsubscribe = NotifyUser::Unsubscribe.create(target: @user, type: type[:type])
         end
       else
         subscribe_to(type[:type])
       end
-    end 
+    end
   end
 
   def unauth_unsubscribe
@@ -152,7 +152,7 @@ class NotifyUser::BaseNotificationsController < ApplicationController
         channel = (type.to_s + "_channel").camelize.constantize
         types[:subscriptions] << {type: type, description: channel.default_options[:description],
           status: NotifyUser::Unsubscribe.has_unsubscribed_from(@user, type).empty?}
-    end 
+    end
 
     #iterates over type
     notification_types.each do |type|

--- a/app/models/notify_user/base_notification.rb
+++ b/app/models/notify_user/base_notification.rb
@@ -56,6 +56,10 @@ module NotifyUser
 
       event :mark_as_sent_as_aggregation_parent do
         transitions from: [:pending_as_aggregation_parent], to: :sent_as_aggregation_parent
+        after do
+          self.sent_time = Time.now
+          self.save
+        end
       end
 
       event :mark_as_pending_as_aggregation_parent do
@@ -141,7 +145,7 @@ module NotifyUser
       # last sent notification
       last_sent_parent = sent_aggregation_parents.first
       # Uses the time of the last notification sent otherwise will send it now.
-      delay_time = last_sent_parent ? last_sent_parent.created_at : created_at
+      delay_time = last_sent_parent ? last_sent_parent.sent_time : created_at
 
       # If this is the first notification the aggregate interval will return 0. Thus sending the notification now!
       return delay_time + a_interval.minutes

--- a/app/models/notify_user/base_notification.rb
+++ b/app/models/notify_user/base_notification.rb
@@ -29,6 +29,7 @@ module NotifyUser
     belongs_to :target, polymorphic: true
 
     validates_presence_of :target_id, :target_type, :target, :type, :state
+    validate :presence_of_target_id
 
     aasm column: :state do
 
@@ -41,12 +42,24 @@ module NotifyUser
       # Email/SMS/APNS has been sent.
       state :sent
 
+      # Identifies which notification within the aggregation window that was actually delayed
+      state :sent_as_aggregation_parent
+      state :pending_as_aggregation_parent
+
       # The user has seen this notification.
       state :read
 
       # Record that we have sent message(s) to the user about this notification.
       event :mark_as_sent do
         transitions from: [:pending, :pending_no_aggregation], to: :sent
+      end
+
+      event :mark_as_sent_as_aggregation_parent do
+        transitions from: [:pending_as_aggregation_parent], to: :sent_as_aggregation_parent
+      end
+
+      event :mark_as_pending_as_aggregation_parent do
+        transitions from: [:pending], to: :pending_as_aggregation_parent
       end
 
       event :dont_aggregate do
@@ -57,7 +70,7 @@ module NotifyUser
       # A notification can go straight from pending to read if it's seen in a view before
       # sent in an email.
       event :mark_as_read do
-        transitions from: [:pending, :sent], to: :read
+        transitions from: [:pending, :sent, :sent_as_aggregation_parent], to: :read
       end
     end
 
@@ -119,6 +132,29 @@ module NotifyUser
       return NotifyUser::UserHash.where(target_id: self.target.id).where(target_type: self.target.class.base_class).where(type: self.type).where(active: true).first || NotifyUser::UserHash.create(target: self.target, type: self.type, active: true)
     end
 
+    def aggregation_interval
+      sent_aggregation_parents.count
+    end
+
+    def delay_time(options)
+      a_interval = options[:aggregate_per][aggregation_interval]
+      # last sent notification
+      last_sent_parent = sent_aggregation_parents.first
+      # Uses the time of the last notification sent otherwise will send it now.
+      delay_time = last_sent_parent ? last_sent_parent.created_at : created_at
+
+      # If this is the first notification the aggregate interval will return 0. Thus sending the notification now!
+      return delay_time + a_interval.minutes
+    end
+
+    def sent_aggregation_parents
+      self.class
+        .for_target(self.target)
+        .where(state: :sent_as_aggregation_parent)
+        .where("params->>'group_id' = ?", params[:group_id].to_s)
+        .order(created_at: :desc)
+    end
+
     ## Notification description
     class_attribute :description
     self.description = ""
@@ -159,7 +195,7 @@ module NotifyUser
     def self.pending_aggregation_with(notification)
       where(type: notification.type)
       .for_target(notification.target)
-      .where(state: :pending)
+      .where(state: :pending_as_aggregation_parent)
     end
 
     def aggregation_pending?
@@ -171,16 +207,24 @@ module NotifyUser
     # Aggregates appropriately
     def deliver
       if pending? and not user_has_unsubscribed?
-        self.mark_as_sent!
 
         # if aggregation is false bypass aggregation completely
         self.channels.each do |channel_name, options|
           if(options[:aggregate_per] == false)
+            self.mark_as_sent!
             self.class.delay.deliver_notification_channel(self.id, channel_name)
           else
-            # only notifies channels if no pending aggreagte notifications
+            # only notifies channels if no pending aggregate notifications
             if not aggregation_pending?
-              self.class.delay_for(options[:aggregate_per] || self.aggregate_per).notify_aggregated_channel(self.id, channel_name)
+              self.mark_as_pending_as_aggregation_parent!
+              # adds fallback support for integer or array of integers
+              if options[:aggregate_per].kind_of?(Array)
+                self.class.delay_until(delay_time(options)).notify_aggregated_channel(self.id, channel_name)
+              else
+                a_interval = options[:aggregate_per] || self.aggregate_per
+                self.class.delay_for(a_interval).notify_aggregated_channel(self.id, channel_name)
+              end
+
             end
           end
         end
@@ -258,6 +302,14 @@ module NotifyUser
     end
 
     private
+
+    def presence_of_target_id
+      self.channels.each do |channel_name, options|
+        if options[:aggregate_grouping] && params[:group_id].blank?
+          errors.add(:params, "requires group_id when aggregate_grouping is set to true")
+        end
+      end
+    end
 
     def unsubscribed_validation
       errors.add(:target, (" has unsubscribed from this type")) if user_has_unsubscribed?

--- a/app/models/notify_user/base_notification.rb
+++ b/app/models/notify_user/base_notification.rb
@@ -153,7 +153,7 @@ module NotifyUser
     end
 
     def sent_aggregation_parents
-      self.class
+      notifications = self.class
         .for_target(self.target)
         .where(state: :sent_as_aggregation_parent)
         .where("params->>'group_id' = ?", params[:group_id].to_s)

--- a/app/models/notify_user/base_notification.rb
+++ b/app/models/notify_user/base_notification.rb
@@ -51,15 +51,17 @@ module NotifyUser
 
       # Record that we have sent message(s) to the user about this notification.
       event :mark_as_sent do
-        transitions from: [:pending, :pending_no_aggregation], to: :sent
-      end
-
-      event :mark_as_sent_as_aggregation_parent do
-        transitions from: [:pending_as_aggregation_parent], to: :sent_as_aggregation_parent
+        transitions from: [:pending_as_aggregation_parent], to: :sent_as_aggregation_parent, :if => :pending_as_aggregation_parent?
+        transitions from: [:pending, :pending_no_aggregation], to: :sent, :unless => :pending_as_aggregation_parent?
         after do
           self.sent_time = Time.now
           self.save
         end
+      end
+
+      event :mark_as_sent_as_aggregation_parent do
+        transitions from: [:pending_as_aggregation_parent], to: :sent_as_aggregation_parent
+
       end
 
       event :mark_as_pending_as_aggregation_parent do

--- a/app/models/notify_user/base_notification.rb
+++ b/app/models/notify_user/base_notification.rb
@@ -156,7 +156,7 @@ module NotifyUser
       self.class
       .for_target(self.target)
       .where(state: :sent_as_aggregation_parent)
-      .where("params->>'group_id' = ?", params[:group_id].to_s)
+      .where(group_id: group_id)
       .order(created_at: :desc)
     end
 
@@ -209,14 +209,14 @@ module NotifyUser
       where(type: notification.type)
       .for_target(notification.target)
       .where(state: :pending_as_aggregation_parent)
-      .where("params->>'group_id' = ?", notification.params[:group_id].to_s)
+      .where(group_id: notification.group_id)
     end
 
     # Used to find all pending notifications with aggregation enabled for target
     def self.pending_aggregation_by_group_with(notification)
       for_target(notification.target)
       .where(state: [:pending, :pending_as_aggregation_parent])
-      .where("params->>'group_id' = ?", notification.params[:group_id].to_s)
+      .where(group_id: notification.group_id)
     end
 
     # Used to find all pending notifications for target
@@ -345,8 +345,8 @@ module NotifyUser
 
     def presence_of_group_id
       self.channels.each do |channel_name, options|
-        if options[:aggregate_grouping] && params[:group_id].blank?
-          errors.add(:params, "requires group_id when aggregate_grouping is set to true")
+        if options[:aggregate_grouping] && group_id.blank?
+          errors.add(:group_id, "required when aggregate_grouping is set to true")
         end
       end
     end

--- a/app/models/notify_user/base_notification.rb
+++ b/app/models/notify_user/base_notification.rb
@@ -139,6 +139,10 @@ module NotifyUser
 
     def delay_time(options)
       a_interval = options[:aggregate_per][aggregation_interval]
+
+      # uses the last interval by default once we deplete the intervals
+      a_interval = options[:aggregate_per].last if a_interval.nil?
+
       # last sent notification
       last_sent_parent = sent_aggregation_parents.first
       # Uses the time of the last notification sent otherwise will send it now.
@@ -228,7 +232,7 @@ module NotifyUser
               if options[:aggregate_per].kind_of?(Array)
                 self.class.delay_until(delay_time(options)).notify_aggregated_channel(self.id, channel_name)
               else
-                a_interval = options[:aggregate_per].minutes || self.aggregate_per
+                a_interval = options[:aggregate_per] ? options[:aggregate_per].minutes : self.aggregate_per
                 self.class.delay_for(a_interval).notify_aggregated_channel(self.id, channel_name)
               end
 

--- a/gemfiles/rails40.gemfile.lock
+++ b/gemfiles/rails40.gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: ../
   specs:
-    notify_user (0.1.4)
+    notify_user (0.2.0)
       aasm
       active_model_serializers
       connection_pool

--- a/gemfiles/rails40.gemfile.lock
+++ b/gemfiles/rails40.gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: ../
   specs:
-    notify_user (0.0.29)
+    notify_user (0.1.4)
       aasm
       active_model_serializers
       connection_pool
@@ -23,7 +23,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    aasm (4.0.8)
+    aasm (4.1.0)
     actionmailer (4.0.4)
       actionpack (= 4.0.4)
       mail (~> 2.5.4)
@@ -61,6 +61,7 @@ GEM
       xpath (~> 2.0)
     celluloid (0.15.2)
       timers (~> 1.1.0)
+    coderay (1.1.0)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -73,7 +74,7 @@ GEM
     connection_pool (2.0.0)
     diff-lcs (1.2.5)
     erubis (2.7.0)
-    eventmachine (1.0.6)
+    eventmachine (1.0.7)
     execjs (2.0.2)
     factory_girl (4.4.0)
       activesupport (>= 3.0.0)
@@ -90,12 +91,13 @@ GEM
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.1)
-    kaminari (0.16.2)
+    kaminari (0.16.3)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
+    method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.2)
     minitest (4.7.5)
@@ -105,7 +107,11 @@ GEM
       mini_portile (~> 0.6.0)
     pg (0.17.1)
     polyglot (0.3.4)
-    pubnub (3.7.0)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pubnub (3.7.1)
       eventmachine (~> 1.0)
       json (~> 1.8)
       net-http-persistent (~> 2.9)
@@ -154,6 +160,7 @@ GEM
       json
       redis (>= 3.0.6)
       redis-namespace (>= 1.3.1)
+    slop (3.6.0)
     sprockets (2.12.1)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -191,6 +198,7 @@ DEPENDENCIES
   jquery-rails
   notify_user!
   pg
+  pry
   rails (= 4.0.4)
   rspec-rails
   rspec-sidekiq

--- a/lib/generators/notify_user/aggr_interval_update/USAGE
+++ b/lib/generators/notify_user/aggr_interval_update/USAGE
@@ -1,0 +1,5 @@
+Description:
+    Add sent_time column to notifications
+
+Example:
+    rails generate notify_user:aggr_interval

--- a/lib/generators/notify_user/aggr_interval_update/aggr_interval_generator.rb
+++ b/lib/generators/notify_user/aggr_interval_update/aggr_interval_generator.rb
@@ -1,0 +1,35 @@
+require 'rails/generators/active_record'
+
+class NotifyUser::AggrIntervalGenerator < Rails::Generators::Base
+  include Rails::Generators::Migration
+
+  source_root File.expand_path('../templates', __FILE__)
+
+  def copy_migrations
+    copy_migration "add_sent_time_to_notifications"
+
+    puts "Update successful. You can now run:"
+    puts "  rake db:migrate"
+  end
+
+  # This is defined in ActiveRecord::Generators::Base, but that inherits from NamedBase, so it expects a name argument
+  # which we don't want here. So we redefine it here. Yuck.
+  def self.next_migration_number(dirname)
+    if ActiveRecord::Base.timestamped_migrations
+      Time.now.utc.strftime("%Y%m%d%H%M%S")
+    else
+      "%.3d" % (current_migration_number(dirname) + 1)
+    end
+  end
+
+  protected
+
+    def copy_migration(filename)
+      if self.class.migration_exists?("db/migrate", "#{filename}")
+        say_status("skipped", "Migration #{filename}.rb already exists")
+      else
+        migration_template "#{filename}.rb", "db/migrate/#{filename}.rb"
+      end
+    end
+
+end

--- a/lib/generators/notify_user/aggr_interval_update/templates/add_sent_time_to_notifications.rb
+++ b/lib/generators/notify_user/aggr_interval_update/templates/add_sent_time_to_notifications.rb
@@ -1,0 +1,5 @@
+class AddSentTimeToNotifications < ActiveRecord::Migration
+  def change
+    add_column :notify_user_notifications, :sent_time, :datetime
+  end
+end

--- a/lib/generators/notify_user/install/templates/create_notify_user_notifications.rb
+++ b/lib/generators/notify_user/install/templates/create_notify_user_notifications.rb
@@ -6,6 +6,7 @@ class CreateNotifyUserNotifications < ActiveRecord::Migration
       t.string :target_type
       t.json :params
       t.string :state
+      t.datetime :sent_time
 
       t.timestamps
     end

--- a/lib/generators/notify_user/install/templates/create_notify_user_notifications.rb
+++ b/lib/generators/notify_user/install/templates/create_notify_user_notifications.rb
@@ -8,7 +8,14 @@ class CreateNotifyUserNotifications < ActiveRecord::Migration
       t.string :state
       t.datetime :sent_time
 
+      t.integer :group_id
+      t.integer :parent_id
+
       t.timestamps
     end
+
+    add_index :notify_user_notifications, :group_id
+    add_index :notify_user_notifications, :parent_id
+    add_index :notify_user_notifications, :target_id
   end
 end

--- a/lib/notify_user/version.rb
+++ b/lib/notify_user/version.rb
@@ -1,3 +1,3 @@
 module NotifyUser
-  VERSION = "0.1.4"
+  VERSION = "0.2.0"
 end

--- a/notify_user.gemspec
+++ b/notify_user.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "capybara"
   s.add_development_dependency "awesome_print"
   s.add_development_dependency "test_after_commit"
+  s.add_development_dependency "pry"
 
   s.test_files = Dir["spec/**/*"]
 end

--- a/spec/models/notify_user/notification_spec.rb
+++ b/spec/models/notify_user/notification_spec.rb
@@ -5,7 +5,7 @@ module NotifyUser
 
     let(:user) { User.create({email: "user@example.com" })}
     let(:notification) { NewPostNotification.create({target: user}) }
-    Rails.application.routes.default_url_options[:host]= 'localhost:5000' 
+    Rails.application.routes.default_url_options[:host]= 'localhost:5000'
 
     before :each do
       BaseNotification.any_instance.stub(:mobile_message).and_return("New Notification")
@@ -92,7 +92,7 @@ module NotifyUser
 
           it "schedules notification to be sent through channels" do
             NewPostNotification.should_receive(:delay).and_call_original
-            notification.deliver        
+            notification.deliver
           end
         end
       end
@@ -106,14 +106,14 @@ module NotifyUser
         notification.state.should eq "pending_no_aggregation"
       end
 
-      describe ".deliver_notification_channel" do 
+      describe ".deliver_notification_channel" do
 
           before :each do
             @notification = NewPostNotification.create({target: user})
           end
 
           it "doesn't send if unsubscribed from channel" do
-            unsubscribe = NotifyUser::Unsubscribe.create({target: user, type: "action_mailer"}) 
+            unsubscribe = NotifyUser::Unsubscribe.create({target: user, type: "action_mailer"})
             ActionMailerChannel.should_not_receive(:deliver)
             BaseNotification.deliver_notification_channel(@notification.id, "action_mailer")
           end
@@ -130,12 +130,12 @@ module NotifyUser
           NewPostNotification.should_receive(:deliver_channels)
                               .with(notification.id)
                               .and_call_original
-          notification.deliver!            
+          notification.deliver!
         end
       end
 
       describe "#deliver_channels" do
-        
+
         it "delivers notification to channels" do
           ActionMailerChannel.should_receive(:deliver).once
           NewPostNotification.deliver_channels(notification.id)
@@ -159,6 +159,158 @@ module NotifyUser
       end
 
     end
+
+    describe "interval aggregation" do
+      before :each do
+        Sidekiq::Testing.fake!
+        @aggregate_per = [0, 1, 4, 5]
+        NewPostNotification.class_eval do
+          channel :action_mailer, aggrregate_per: @aggregate_per, aggregate_grouping: true
+        end
+      end
+
+      describe "aggregate interval" do
+        describe "first notification to be received after a notification was sent" do
+          it "first notification returns interval 0" do
+            notification = NewPostNotification.create({target: user, params: {group_id: 1}})
+            expect(notification.aggregation_interval).to eq 0
+          end
+
+          it "second notification returns internal 1" do
+            NewPostNotification.create({target: user, params: {group_id: 1}, state: "sent_as_aggregation_parent"})
+            notification = NewPostNotification.create({target: user, params: {group_id: 1}})
+            expect(notification.aggregation_interval).to eq 1
+          end
+
+          it "third notification returns interval 2" do
+            NewPostNotification.create({target: user, params: {group_id: 1}, state: "sent_as_aggregation_parent"})
+            NewPostNotification.create({target: user, params: {group_id: 1}, state: "sent_as_aggregation_parent"})
+
+            notification = NewPostNotification.create({target: user, params: {group_id: 1}})
+            expect(notification.aggregation_interval).to eq 2
+          end
+
+          it "doesn't include sent notifications from another target_id" do
+            NewPostNotification.create({target: user, params: {group_id: 3}, state: "sent_as_aggregation_parent"})
+            NewPostNotification.create({target: user, params: {group_id: 0}, state: "sent_as_aggregation_parent"})
+
+            notification = NewPostNotification.create({target: user, params: {group_id: 1}})
+            expect(notification.aggregation_interval).to eq 0
+          end
+        end
+      end
+
+      describe "delay_time" do
+        it "first notification will return Time.now" do
+          notification = NewPostNotification.create({target: user, params: {group_id: 1}})
+          expect(notification.delay_time({aggregate_per: @aggregate_per})).to eq n.created_at + 1.minute
+        end
+
+        it "notification received during first interval returns last time + x.minutes " do
+          n = NewPostNotification.create({target: user, params: {group_id: 1}, state: "sent_as_aggregation_parent"})
+
+          notification = NewPostNotification.create({target: user, params: {group_id: 1}})
+          expect(notification.delay_time({aggregate_per: @aggregate_per})).to eq n.created_at + 1.minute
+        end
+
+        it "notification returned during third interval returns last time + x.minutes" do
+          NewPostNotification.create({target: user, params: {group_id: 1}, state: "sent_as_aggregation_parent"})
+          n = NewPostNotification.create({target: user, params: {group_id: 1}, state: "sent_as_aggregation_parent"})
+
+          notification = NewPostNotification.create({target: user, params: {group_id: 1}})
+          expect(notification.delay_time({aggregate_per: @aggregate_per})).to eq n.created_at + 4.minute
+        end
+      end
+
+      describe "the first notification" do
+        before :each do
+          @notification = NewPostNotification.create({target: user, params: {group_id: 1}})
+        end
+
+        it "should send immediately" do
+          expect{
+            @notification.deliver
+          }.to change(Sidekiq::Extensions::DelayedClass.jobs, :size).by(1)
+        end
+
+        it "should change state to sent_as_aggregate_parent" do
+          expect{
+            @notification.deliver
+          }.to change(@notification, :state).to "pending_as_aggregation_parent"
+        end
+      end
+
+      describe "receive subsequent notifications" do
+
+        describe "with no pending notifications" do
+          it "send immediately if time progressed >= than current interval.minute" do
+            n = NewPostNotification.create({target: user, params: {group_id: 1}, state: "sent_as_aggregation_parent"})
+            notification = NewPostNotification.create({target: user, params: {group_id: 1}, created_at: n.created_at + 2.minutes})
+
+            expect{
+              notification.deliver
+            }.to change(Sidekiq::Extensions::DelayedClass.jobs, :size).by(1)
+          end
+
+          it "delay for x.minutes if time progressed < than current interval.minute" do
+
+          end
+        end
+
+        describe "with pending notifications" do
+          before :each do
+            @other_notification = NewPostNotification.create({target: user, state: "pending_as_aggregation_parent"})
+          end
+
+          it "dont delay anything" do
+            expect{
+              @notification.deliver
+            }.to change(Sidekiq::Extensions::DelayedClass.jobs, :size).by(0)
+          end
+
+          it "state remains as pending" do
+            @notification.deliver
+            expect(@notification.reload.pending?).to eq true
+          end
+        end
+      end
+      #we need a way to identify which notification was the one that was delayed conceptually labeled "head" or a special state
+      #search how many unread/sent "head" notifications exist and use that as the interval
+    end
+
+    describe "validations" do
+      describe "aggregate_grouping false" do
+        before :each do
+          NewPostNotification.class_eval do
+            channel :action_mailer, aggrregate_per: [1, 4, 5]
+          end
+        end
+
+        it "doesn't require a params_target_id" do
+          notification = NewPostNotification.new({target: user})
+          expect(notification).to be_valid
+        end
+      end
+
+      describe "aggregate_grouping true" do
+        before :each do
+          NewPostNotification.class_eval do
+            channel :action_mailer, aggrregate_per: [1, 4, 5], aggregate_grouping: true
+          end
+        end
+
+        it "if group_id present be valid" do
+          notification = NewPostNotification.new({target: user, params: {group_id: 0}})
+          expect(notification).to be_valid
+        end
+        it "if aggregate_grouping is true require a params_group_id" do
+          notification = NewPostNotification.new({target: user})
+          expect(notification).to_not be_valid
+        end
+      end
+
+    end
+
 
     describe "generate hash" do
       it "creates a new hash if an active hash doesn't already exist" do

--- a/spec/models/notify_user/notification_spec.rb
+++ b/spec/models/notify_user/notification_spec.rb
@@ -77,7 +77,7 @@ module NotifyUser
           end
 
           it "doesn't schedule a job if a pending notification awaiting aggregation already exists" do
-            another_notification = NewPostNotification.create({target: user})
+            another_notification = NewPostNotification.create({target: user, state: "pending_as_aggregation_parent"})
             NewPostNotification.should_not_receive(:delay_for)
                             .with(notification.class.aggregate_per).and_call_original
 
@@ -214,17 +214,17 @@ module NotifyUser
         end
 
         it "notification received during first interval returns last time + x.minutes " do
-          n = NewPostNotification.create({target: user, params: {group_id: 1}, state: "pending_as_aggregation_parent"})
-          n.mark_as_sent_as_aggregation_parent!
+          n = NewPostNotification.create!({target: user, params: {group_id: 1}, state: "pending_as_aggregation_parent"})
+          n.mark_as_sent!
 
-          notification = NewPostNotification.create({target: user, params: {group_id: 1}})
+          notification = NewPostNotification.create!({target: user, params: {group_id: 1}})
           expect(notification.delay_time({aggregate_per: @aggregate_per})).to eq n.sent_time + 1.minute
         end
 
         it "notification returned during third interval returns last time + x.minutes" do
-          NewPostNotification.create({target: user, params: {group_id: 1}, state: "pending_as_aggregation_parent"}).mark_as_sent_as_aggregation_parent!
+          NewPostNotification.create({target: user, params: {group_id: 1}, state: "pending_as_aggregation_parent"}).mark_as_sent!
           n = NewPostNotification.create({target: user, params: {group_id: 1}, state: "pending_as_aggregation_parent"})
-          n.mark_as_sent_as_aggregation_parent!
+          n.mark_as_sent!
 
           notification = NewPostNotification.create({target: user, params: {group_id: 1}})
           expect(notification.delay_time({aggregate_per: @aggregate_per})).to eq n.sent_time + 4.minute

--- a/spec/models/notify_user/notification_spec.rb
+++ b/spec/models/notify_user/notification_spec.rb
@@ -253,7 +253,7 @@ module NotifyUser
           }.to change(Sidekiq::Extensions::DelayedClass.jobs, :size).by(1)
         end
 
-        it "should change state to sent_as_aggregate_parent" do
+        it "should change state to pending_as_aggregation_parent" do
           expect{
             @notification.deliver
           }.to change(@notification, :state).to "pending_as_aggregation_parent"
@@ -271,6 +271,7 @@ module NotifyUser
               notification.deliver
             }.to change(Sidekiq::Extensions::DelayedClass.jobs, :size).by(1)
           end
+
         end
 
         describe "with pending notifications" do

--- a/spec/models/notify_user/notification_spec.rb
+++ b/spec/models/notify_user/notification_spec.rb
@@ -230,7 +230,16 @@ module NotifyUser
           expect(notification.delay_time({aggregate_per: @aggregate_per})).to eq n.sent_time + 4.minute
         end
 
-        it "notification received after all intervals have ended just uses the last interval"
+        it "notification received after all intervals have ended just uses the last interval" do
+          10.times do
+            NewPostNotification.create({target: user, params: {group_id: 1}, state: "pending_as_aggregation_parent"}).mark_as_sent!
+          end
+          last_n = NewPostNotification.create({target: user, params: {group_id: 1}, state: "pending_as_aggregation_parent"})
+          last_n.mark_as_sent!
+
+          notification = NewPostNotification.create({target: user, params: {group_id: 1}})
+          expect(notification.delay_time({aggregate_per: @aggregate_per})).to eq last_n.sent_time + 5.minute
+        end
       end
 
       describe "the first notification" do

--- a/spec/models/notify_user/notification_spec.rb
+++ b/spec/models/notify_user/notification_spec.rb
@@ -169,6 +169,12 @@ module NotifyUser
         end
       end
 
+      it "marking a pending_as_aggregation_parent as sent sets it to sent_as_aggregation_parent" do
+        notification = NewPostNotification.create({target: user, params: {group_id: 1}, state: "pending_as_aggregation_parent"})
+        notification.mark_as_sent!
+        expect(notification.reload.state).to eq "sent_as_aggregation_parent"
+      end
+
       describe "aggregate interval" do
         describe "first notification to be received after a notification was sent" do
           it "first notification returns interval 0" do
@@ -260,8 +266,8 @@ module NotifyUser
 
         describe "with pending notifications" do
           before :each do
-            @other_notification = NewPostNotification.create({target: user, state: "pending_as_aggregation_parent"})
-            @notification = NewPostNotification.create({target: user})
+            @other_notification = NewPostNotification.create({target: user, state: "pending_as_aggregation_parent", params: {group_id: 1}})
+            @notification = NewPostNotification.create({target: user, params: {group_id: 1}})
           end
 
           it "dont delay anything" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,7 +23,7 @@ require 'sidekiq'
 require File.expand_path("#{ENV['RAILS_ROOT']}/config/environment.rb",  __FILE__)
 
 puts "Testing with Rails #{Rails::VERSION::STRING} and Ruby #{RUBY_VERSION}"
-
+require 'pry'
 require 'rspec/rails'
 require 'capybara/rails'
 require 'factory_girl_rails'


### PR DESCRIPTION
Lays the ground work for aggregating notifications at custom intervals for instance [0, 1, 5, 10].
For instance the first notification I receive send immediately, if I receive another message before I read the previous one send it a minute after and then 5 minutes after and so fourth. 

