### PR TITLE
Fixed aggregation_interval bug where it was consdering itself in the …

### DIFF
--- a/lib/generators/notify_user/install/install_generator.rb
+++ b/lib/generators/notify_user/install/install_generator.rb
@@ -25,11 +25,8 @@ class NotifyUser::InstallGenerator < Rails::Generators::Base
   # This is defined in ActiveRecord::Generators::Base, but that inherits from NamedBase, so it expects a name argument
   # which we don't want here. So we redefine it here. Yuck.
   def self.next_migration_number(dirname)
-    if ActiveRecord::Base.timestamped_migrations
-      Time.now.utc.strftime("%Y%m%d%H%M%S%L%N")
-    else
-      "%.3d" % (current_migration_number(dirname) + 1)
-    end
+    next_migration_number = current_migration_number(dirname) + 1
+    ActiveRecord::Migration.next_migration_number(next_migration_number)
   end
 
   protected

--- a/spec/models/notify_user/notification_spec.rb
+++ b/spec/models/notify_user/notification_spec.rb
@@ -240,6 +240,14 @@ module NotifyUser
             notification = NewPostNotification.create({target: user, group_id: 1})
             expect(notification.aggregation_interval).to eq 0
           end
+
+          it "agregation interval should include pending as parent states as well" do
+            NewPostNotification.create({target: user, group_id: 1, state: "sent_as_aggregation_parent"})
+            NewPostNotification.create({target: user, group_id: 1, state: "pending_as_aggregation_parent"})
+
+            notification = NewPostNotification.create({target: user, group_id: 1})
+            expect(notification.aggregation_interval).to eq 2
+          end
         end
       end
 
@@ -318,7 +326,7 @@ module NotifyUser
 
           it "parent_id gets set to notification at interval 0" do
             notification = NewPostNotification.create({target: user, group_id: 1, created_at: @n.created_at + 2.minutes})
-            notification.deliver
+            notification.notify
             expect(notification.reload.parent_id).to eq @n.id
           end
 
@@ -340,12 +348,6 @@ module NotifyUser
           it "state remains as pending" do
             @notification.deliver
             expect(@notification.reload.pending?).to eq true
-          end
-
-          it "parent_id gets set to notification at interval 0" do
-            notification = NewPostNotification.create({target: user, group_id: 1, created_at: @n.created_at + 2.minutes})
-            notification.deliver
-            expect(notification.reload.parent_id).to eq @n.id
           end
 
         end


### PR DESCRIPTION
…caluclation. Also save calls within an after_commit:create block would re-run the same block. Had to move update.parent_id to notify