### PR TITLE
Removes the `badge` key from push options for silent notifications

### DIFF
--- a/app/models/notify_user/houston.rb
+++ b/app/models/notify_user/houston.rb
@@ -62,7 +62,7 @@ module NotifyUser
           alert: '',
           sound: '',
           content_available: true
-        })
+        }).delete(:badge)
       end
 
       push_options

--- a/spec/models/notify_user/houston_spec.rb
+++ b/spec/models/notify_user/houston_spec.rb
@@ -34,6 +34,12 @@ module NotifyUser
         expect(@houston.push_options[:sound]).to eq 'special.wav'
       end
 
+      it 'should remove the badge key for silent notifications' do
+        @houston = NotifyUser::Houston.new([notification], { silent: true })
+
+        expect(@houston.push_options).not_to have_key(:badge)
+      end
+
       xit "should initialize with many notifications" do
         expect(NotifyUser::BaseNotification).to receive(:aggregate_message).and_return("New Notification")
         notifications = NewPostNotification.create([{target: user}, {target: user}, {target: user}])


### PR DESCRIPTION
Currently silent notifications were changing the badge count on the app, removing the `badge` key means that the current badge on the app won't be changed.