### PR TITLE
Allow custom pem file paths

### DIFF
--- a/app/models/notify_user/apn_connection.rb
+++ b/app/models/notify_user/apn_connection.rb
@@ -35,18 +35,27 @@ module NotifyUser
         Rails.logger.info "Using development gateway. Rails env: #{Rails.env}, APN_ENVIRONMENT: #{apn_environment}"
         [
           ::Houston::APPLE_DEVELOPMENT_GATEWAY_URI,
-          File.read("#{Rails.root}/config/keys/development_push.pem")
+          File.read(development_certificate)
         ]
       else
         Rails.logger.info "Using production gateway. Rails env: #{Rails.env}, APN_ENVIRONMENT: #{apn_environment}"
         [
           ::Houston::APPLE_PRODUCTION_GATEWAY_URI,
-          File.read("#{Rails.root}/config/keys/production_push.pem")
+          File.read(production_certificate)
         ]
       end
 
       @connection = ::Houston::Connection.new(@uri, @certificate, nil)
     end
 
+    def development_certificate
+      file_path = ENV['APN_DEVELOPMENT_PATH'] || 'config/keys/development_push.pem'
+      "#{Rails.root}/#{file_path}"
+    end
+
+    def production_certificate
+      file_path = ENV['APN_PRODUCTION_PATH'] || "config/keys/production_push.pem"
+      "#{Rails.root}/#{file_path}"
+    end
   end
 end

--- a/spec/models/notify_user/apn_connection_spec.rb
+++ b/spec/models/notify_user/apn_connection_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+module NotifyUser
+  describe APNConnection do
+    describe 'pem file paths' do
+      before :each do
+        @connection = described_class.new
+      end
+
+      it 'has the correct default development path' do
+        expect(@connection.send(:development_certificate)).to eq "#{Rails.root}/config/keys/development_push.pem"
+      end
+
+      it 'has the correct default production path' do
+        expect(@connection.send(:production_certificate)).to eq "#{Rails.root}/config/keys/production_push.pem"
+      end
+
+      it 'can set a custom path for development' do
+        ENV['APN_DEVELOPMENT_PATH'] = 'path/to/key.pem'
+        expect(@connection.send(:development_certificate)).to eq "#{Rails.root}/path/to/key.pem"
+      end
+
+      it 'can set a custom path for production' do
+        ENV['APN_PRODUCTION_PATH'] = 'path/to/key.pem'
+        expect(@connection.send(:production_certificate)).to eq "#{Rails.root}/path/to/key.pem"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Can now specify paths to the various pem files as Environment variables.

The use case here is for Vent - we can specify different pem files for different bundle ids.