### PR TITLE
Fix/houston threading

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,17 +53,6 @@ wwtd
 ## APNS providers
 By default, we use [Houston](https://github.com/nomad/houston/) to deliver push notifications via APNS from the server.
 
-The initialiser for `notify_user` contains the following configuration when delivering via Houston:
-```
-# Number of connections Houston will maintain to APNS:
-config.connection_pool_size = 3
-
-# Time in seconds Houston will wait for a free connection before failing:
-config.connection_pool_timeout = 300
-```
-
-We maintain persistent connections to APNS via background workers, and these values will allow you to configure how many connections the workers maintain, as well as the amount of time to wait for an idle connection before timing out.
-
 You also need to provide exported versions of your push notification certificate and key as .pem files, these instructions come from the [APN on Rails](https://github.com/PRX/apn_on_rails) project on how to do that:
 
 Once you have the certificate from Apple for your application, export your key

--- a/app/models/notify_user/apn_connection.rb
+++ b/app/models/notify_user/apn_connection.rb
@@ -1,6 +1,10 @@
 module NotifyUser
   class APNConnection
 
+    POOL = ConnectionPool.new(size: ENV['APNS_CONNECTION_POOL_SIZE'] || 1, timeout: ENV['APNS_CONNECTION_TIMEOUT'] || 30) {
+      APNConnection.new
+    }
+
     def initialize
       connection
     end

--- a/app/models/notify_user/apns.rb
+++ b/app/models/notify_user/apns.rb
@@ -16,8 +16,8 @@ module NotifyUser
     end
 
     def push
-      APNConnection::POOL.with do |apn_connection|
-        @apn_connection = apn_connection
+      APNConnection::POOL.with do |apn_conn|
+        @apn_connection = apn_conn
         send_notifications
       end
     end

--- a/lib/generators/notify_user/install/templates/initializer.rb
+++ b/lib/generators/notify_user/install/templates/initializer.rb
@@ -14,11 +14,4 @@ NotifyUser.setup do |config|
 
   # Provider for APNS:
   config.apns_provider = :houston
-
-  # Number of connections Houston will maintain to APNS:
-  config.connection_pool_size = 3
-
-  # Time in seconds Houston will wait for a free connection before failing:
-  config.connection_pool_timeout = 300
-
 end

--- a/lib/notify_user.rb
+++ b/lib/notify_user.rb
@@ -20,14 +20,6 @@ module NotifyUser
   mattr_accessor :apns_provider
   @@apns_provider = nil
 
-  # Number of connections Houston will maintain to APNS:
-  mattr_accessor :connection_pool_size
-  @@connection_pool_size = nil
-
-  # Time in seconds Houston will wait for a free connection before failing:
-  mattr_accessor :connection_pool_timeout
-  @@connection_pool_timeout = nil
-
   # Used to set up NotifyUser from the initializer.
   def self.setup
     yield self

--- a/notify_user.gemspec
+++ b/notify_user.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", ">= 3.2"
   s.add_dependency "aasm"
   s.add_dependency "sidekiq", ">= 3.0.0"
-  s.add_dependency "connection_pool", ">= 2.2.0"
   s.add_dependency "kaminari"
   s.add_dependency "active_model_serializers"
   s.add_dependency "pubnub"

--- a/notify_user.gemspec
+++ b/notify_user.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", ">= 3.2"
   s.add_dependency "aasm"
   s.add_dependency "sidekiq", ">= 3.0.0"
+  s.add_dependency "connection_pool", ">= 2.2.0"
   s.add_dependency "kaminari"
   s.add_dependency "active_model_serializers"
   s.add_dependency "pubnub"


### PR DESCRIPTION
  - Use a connection pool to avoid using the same OpenSSL connection from multiple threads when using Houston within Sidekiq.