### PR TITLE
Add optional 'sendable_attributes' to notification class to filter wh…

### DIFF
--- a/app/models/notify_user/apns.rb
+++ b/app/models/notify_user/apns.rb
@@ -50,7 +50,7 @@ module NotifyUser
         alert: mobile_message,
         badge: @notification.count_for_target,
         category: @notification.params[:category] || @notification.type,
-        custom_data: @notification.params,
+        custom_data: @notification.sendable_params,
         sound: @options[:sound] || 'default'
       }
 

--- a/app/models/notify_user/base_notification.rb
+++ b/app/models/notify_user/base_notification.rb
@@ -83,6 +83,12 @@ module NotifyUser
       end
     end
 
+    def sendable_params
+      return params unless self.class.sendable_attributes.any?
+
+      params.slice(*self.class.sendable_attributes.map(&:to_s))
+    end
+
     # returns the global unread notification count for a user
     def count_for_target
       NotifyUser::BaseNotification.for_target(target)
@@ -195,6 +201,13 @@ module NotifyUser
 
     class_attribute :aggregate_per
     self.aggregate_per = 1.minute
+
+    class_attribute :sendable_attributes
+    self.sendable_attributes = []
+
+    def self.allow_sendable_attributes(*args)
+      self.sendable_attributes = *args
+    end
 
     ## True will implement a grouping/aggregation algorithm so that even though 10 notifications are delivered eg. Push Notifications
     ## Only 1 notification will be displayed to the user within the notification.json payload

--- a/app/models/notify_user/gcm.rb
+++ b/app/models/notify_user/gcm.rb
@@ -43,7 +43,7 @@ module NotifyUser
           message: mobile_message,
           type: @options[:category] || @notification.type,
           unread_count: @notification.count_for_target,
-          custom_data: @notification.params,
+          custom_data: @notification.sendable_params,
         }
       }
     end

--- a/spec/models/notify_user/apns_spec.rb
+++ b/spec/models/notify_user/apns_spec.rb
@@ -25,7 +25,7 @@ module NotifyUser
         end
 
         it 'sets the custom data with params' do
-          expect(@apns.push_options[:custom_data]).to eq notification.params
+          expect(@apns.push_options[:custom_data]).to eq notification.sendable_params
         end
 
         it 'has a default sound' do

--- a/spec/models/notify_user/gcm_spec.rb
+++ b/spec/models/notify_user/gcm_spec.rb
@@ -23,7 +23,7 @@ module NotifyUser
             message: notification.mobile_message,
             type: notification.class.name,
             unread_count: 1,
-            custom_data: notification.params
+            custom_data: notification.sendable_params
           }
         )
       end

--- a/spec/models/notify_user/notification_spec.rb
+++ b/spec/models/notify_user/notification_spec.rb
@@ -873,5 +873,53 @@ module NotifyUser
         expect(another_hash.token).not_to eq user_hash.token
       end
     end
+
+    describe '.sendable_attributes' do
+      it 'has a default of an empty array' do
+        class TestNotificationWithoutSendableAttributes < BaseNotification; end
+
+        expect(TestNotificationWithoutSendableAttributes.sendable_attributes).to eq []
+      end
+
+      it 'can have configurable attributes' do
+        class TestNotificationWithSendableAttributes < BaseNotification
+          allow_sendable_attributes \
+            :id,
+            :foo
+        end
+
+        expect(TestNotificationWithSendableAttributes.sendable_attributes).to eq [:id, :foo]
+      end
+    end
+
+    describe '#sendable_params' do
+      subject do
+        TestNotification.create(
+          target: user,
+          params: {
+            'foo' => 'bar',
+            'bar' => 'baz',
+            'quux' => 'quuz'
+          }
+        )
+      end
+
+      it 'falls back to params' do
+        expect(subject.sendable_params).to eq ({
+          'foo' => 'bar',
+          'bar' => 'baz',
+          'quux' => 'quuz'
+        })
+      end
+
+      it 'filters to whitelisted attributes' do
+        allow(TestNotification).to receive(:sendable_attributes) { [:foo, :bar] }
+
+        expect(subject.sendable_params).to eq({
+          'foo' => 'bar',
+          'bar' => 'baz'
+        })
+      end
+    end
   end
 end


### PR DESCRIPTION
…ich params get send over the wire
