### PR TITLE
Ensure we are passing the channel options when delivering aggregated …

### DIFF
--- a/app/models/notify_user/base_notification.rb
+++ b/app/models/notify_user/base_notification.rb
@@ -483,11 +483,12 @@ module NotifyUser
 
     def self.mutli_deliver(notifications, channel_class)
       return if notifications.empty? || notifications.first.user_has_unsubscribed?(channel_class.name)
+      options = channels[channel_class.name.underscore.gsub('_channel', '').to_sym]
 
       if notifications.length == 1
-        channel_class.delay.deliver(notifications.first.id)
+        channel_class.delay.deliver(notifications.first.id, options)
       else
-        channel_class.delay.deliver_aggregated(notifications.map(&:id))
+        channel_class.delay.deliver_aggregated(notifications.map(&:id), options)
       end
     end
   end


### PR DESCRIPTION
…notifications

The previous refactor was calling deliver and deliver_aggregated
 on a channel class without passing through the channel options,
this in particular meant that the notification sound wasn't being
passed to APNS, so notifications were arriving with the default
iOS sound, instead of the one we wanted.

By ensuring we find the particular channel's options in `multi_deliver`
we pass through everything we know about the channel that might be
relevant
