### PR TITLE
Pass the delivery_id to the delivery worker

### DIFF
--- a/app/models/notify_user/delivery.rb
+++ b/app/models/notify_user/delivery.rb
@@ -13,7 +13,7 @@ module NotifyUser
     private
 
     def deliver!
-      DeliveryWorker.perform_in(deliver_in)
+      DeliveryWorker.perform_in(deliver_in, id)
     end
   end
 end

--- a/spec/models/notify_user/delivery_spec.rb
+++ b/spec/models/notify_user/delivery_spec.rb
@@ -18,10 +18,10 @@ module NotifyUser
       end
 
       it 'schedules a delivery worker for the channel' do
-        delivery = build(:delivery, deliver_in: 0, notification: @notification, channel: 'apns')
+        delivery = build(:delivery, deliver_in: 0, notification: @notification, channel: 'apns', id: 3749)
 
         TestAfterCommit.with_commits(true) do
-          expect(NotifyUser::DeliveryWorker).to receive(:perform_in).with(0.seconds)
+          expect(NotifyUser::DeliveryWorker).to receive(:perform_in).with(0.seconds, 3749)
           delivery.save
         end
       end


### PR DESCRIPTION
Also fixes #37 deprecation warning for Rails 5.0
