### PR TITLE
Feature/delivery factory

### DIFF
--- a/app/models/notify_user/delivery_generator.rb
+++ b/app/models/notify_user/delivery_generator.rb
@@ -15,14 +15,14 @@ module NotifyUser
 
   class ApnsDeliveryGenerator < DeliveryGenerator
     def generate(notification, options)
-      fetch_devices(notification).each do |device|
-        Delivery.create!(options.merge(device: device))
+      fetch_device_tokens(notification).each do |token|
+        Delivery.create!(options.merge(device_token: token))
       end
     end
 
     private
 
-    def fetch_devices(notification)
+    def fetch_device_tokens(notification)
       # TODO: Figure out how to make this configureable, at the moment it's locked to how Dre works:
       devices = notification.target.devices
       devices.ios.pluck(:token)
@@ -34,14 +34,14 @@ module NotifyUser
 
   class GcmDeliveryGenerator < DeliveryGenerator
     def generate(notification, options)
-      fetch_devices(notification).each do |device|
-        Delivery.create!(options.merge(device: device))
+      fetch_device_tokens(notification).each do |token|
+        Delivery.create!(options.merge(device_token: token))
       end
     end
 
     private
 
-    def fetch_devices(notification)
+    def fetch_device_tokens(notification)
       # TODO: Figure out how to make this configureable, at the moment it's locked to how Dre works:
       devices = notification.target.devices
       devices.android.pluck(:token)

--- a/app/models/notify_user/delivery_generator.rb
+++ b/app/models/notify_user/delivery_generator.rb
@@ -1,0 +1,53 @@
+module NotifyUser
+  class DeliveryGenerator
+    def generate(notification, options)
+      Delivery.create!(options)
+    end
+
+    def self.for(channel)
+      begin
+        const_get("NotifyUser::#{channel.camelize}DeliveryGenerator")
+      rescue NameError
+        DeliveryGenerator
+      end.new
+    end
+  end
+
+  class ApnsDeliveryGenerator < DeliveryGenerator
+    def generate(notification, options)
+      fetch_devices(notification).each do |device|
+        Delivery.create!(options.merge(device: device))
+      end
+    end
+
+    private
+
+    def fetch_devices(notification)
+      # TODO: Figure out how to make this configureable, at the moment it's locked to how Dre works:
+      devices = notification.target.devices
+      devices.ios.pluck(:token)
+    rescue
+      Rails.logger.info "Notification target, #{notification.target.class}, does not respond to the method, #devices."
+      []
+    end
+  end
+
+  class GcmDeliveryGenerator < DeliveryGenerator
+    def generate(notification, options)
+      fetch_devices(notification).each do |device|
+        Delivery.create!(options.merge(device: device))
+      end
+    end
+
+    private
+
+    def fetch_devices(notification)
+      # TODO: Figure out how to make this configureable, at the moment it's locked to how Dre works:
+      devices = notification.target.devices
+      devices.android.pluck(:token)
+    rescue
+      Rails.logger.info "Notification target, #{notification.target.class}, does not respond to the method, #devices."
+      []
+    end
+  end
+end

--- a/app/models/notify_user/gcm.rb
+++ b/app/models/notify_user/gcm.rb
@@ -4,15 +4,11 @@ module NotifyUser
   class Gcm < Push
     PAYLOAD_LIMIT = 4096
 
-    attr_accessor :client, :push_options
-
-    def initialize(notifications, devices, options)
-      super(notifications, devices, options)
-    end
-
     def push
       send_notifications
     end
+
+    private
 
     def client
       @client ||= GCM.new(ENV['GCM_API_KEY'])
@@ -22,19 +18,36 @@ module NotifyUser
       payload.to_json.bytesize <= PAYLOAD_LIMIT
     end
 
-    private
+    def send_notifications
+      device = fetch_device(delivery.notification, delivery.device_token)
+      fail "Device not registered for target" unless device
 
-    def build_notification
-      return Factories::Gcm.build(@notification, @options)
+      notification_data = build_notification(delivery.notification)
+      response = client.send(device.token, notification_data)
+
+      log_response_to_delivery(response)
+      handle_response(response, device)
     end
 
-    def send_notifications
-      return unless device_tokens.any?
-      notification_data = build_notification()
+    def fetch_device(notification, device_token)
+      notification.target.devices.find_by(token: device_token)
+    end
 
-      response = client.send(device_tokens, notification_data)
-      # should be checking for errors in the response here
-      return true
+    def build_notification(notification)
+      return Factories::Gcm.build(notification, options)
+    end
+
+    def log_response_to_delivery(response)
+      body = JSON.parse(response[:body])
+      delivery.update(status: response[:status_code], reason: body['results'][0]['error'])
+    end
+
+    def handle_response(response, device)
+      body = JSON.parse(response[:body])
+
+      if body['failure'] > 0 && (body['results'][0]['error'] == 'InvalidRegistration' || body['results'][0]['error'] == 'NotRegistered')
+        device.destroy
+      end
     end
   end
 end

--- a/app/models/notify_user/push.rb
+++ b/app/models/notify_user/push.rb
@@ -1,10 +1,10 @@
 module NotifyUser
   class Push
-    def initialize(notifications, devices, options)
-      @notifications = notifications
-      @notification = notifications.first
 
-      @devices = devices
+    attr_reader :delivery, :options
+
+    def initialize(delivery, options)
+      @delivery = delivery
       @options = options
     end
 
@@ -13,12 +13,5 @@ module NotifyUser
       raise "Base Push class should not be used."
     end
 
-    private
-
-    attr_accessor :device_tokens
-
-    def device_tokens
-      @device_tokens = @devices.map(&:token)
-    end
   end
 end

--- a/app/models/notify_user/scheduler.rb
+++ b/app/models/notify_user/scheduler.rb
@@ -14,14 +14,13 @@ module NotifyUser
         return if aggregator.has_pending_deliveries?
 
         # Create the delivery:
-        delivery_generator = DeliveryGenerator.for(channel)
         options = {
           notification: notification,
           deliver_in: delay_time(aggregator),
           channel: channel.to_s
         }
 
-        delivery_generator.generate(notification, options)
+        DeliveryGenerator.for(channel).generate(notification, options)
       end
     end
 

--- a/app/models/notify_user/scheduler.rb
+++ b/app/models/notify_user/scheduler.rb
@@ -14,11 +14,14 @@ module NotifyUser
         return if aggregator.has_pending_deliveries?
 
         # Create the delivery:
-        delivery = Delivery.create!({
+        delivery_generator = DeliveryGenerator.for(channel)
+        options = {
           notification: notification,
           deliver_in: delay_time(aggregator),
           channel: channel.to_s
-        })
+        }
+
+        delivery_generator.generate(notification, options)
       end
     end
 

--- a/app/workers/notify_user/delivery_worker.rb
+++ b/app/workers/notify_user/delivery_worker.rb
@@ -12,7 +12,7 @@ module NotifyUser
         channel_options = delivery.notification.class.channels[channel_name.to_sym] || {}
         channel_class = (channel_name + "_channel").camelize.constantize
 
-        channel_class.deliver(delivery.notification_id, channel_options)
+        channel_class.deliver(delivery.id, channel_options)
         delivery.update(sent_at: Time.zone.now)
       end
     end

--- a/lib/generators/notify_user/install/templates/create_notify_user_deliveries.rb
+++ b/lib/generators/notify_user/install/templates/create_notify_user_deliveries.rb
@@ -4,8 +4,11 @@ class CreateNotifyUserDeliveries < ActiveRecord::Migration
       t.datetime :sent_at
       t.string :channel
       t.integer :deliver_in
+      t.string :status
+      t.string :reason
 
       t.integer :notification_id
+      t.string :device_token
 
       t.timestamps
     end

--- a/lib/notify_user/channels/apns/apns_channel.rb
+++ b/lib/notify_user/channels/apns/apns_channel.rb
@@ -7,41 +7,13 @@ class ApnsChannel
   	  }
   	end
 
-    def deliver(notification_id, options={})
-      if notification_id.is_a? NotifyUser::BaseNotification
-        raise RuntimeError, "Must pass notification ids, not the notification itself"
+    def deliver(delivery_id, options={})
+      if delivery_id.is_a? NotifyUser::BaseNotification
+        raise RuntimeError, "Must pass delivery id, not the delivery itself"
       end
 
-      notification = NotifyUser::BaseNotification.find(notification_id)
-
-      devices = fetch_devices(notification, options[:device_method])
-
-      NotifyUser::Apns.new([notification], devices, options).push if devices.any?
-    end
-
-    def deliver_aggregated(notification_ids, options={})
-      if notification_ids.first.is_a? NotifyUser::BaseNotification
-        raise RuntimeError, "Must pass notification ids, not the notifications themselves"
-      end
-
-      notifications = NotifyUser::BaseNotification.where(id: notification_ids)
-
-      devices = fetch_devices(notifications.first, options[:device_method])
-
-      NotifyUser::Apns.new(notifications, devices, options).push if devices.any?
-    end
-
-    private
-
-    def fetch_devices(notification, device_method = nil)
-      device_method ||= :devices
-      devices = notification.target.send(device_method)
-
-      devices.ios.to_a
-    rescue
-      [].tap do
-        Rails.logger.info "Notification target, #{notification.target.class}, does not respond to the method, #{device_method}."
-      end
+      delivery = NotifyUser::Delivery.find(delivery_id)
+      NotifyUser::Apns.new(delivery, options).push
     end
   end
 end

--- a/lib/notify_user/channels/apns/apns_channel.rb
+++ b/lib/notify_user/channels/apns/apns_channel.rb
@@ -8,7 +8,7 @@ class ApnsChannel
   	end
 
     def deliver(delivery_id, options={})
-      if delivery_id.is_a? NotifyUser::BaseNotification
+      if delivery_id.is_a? NotifyUser::Delivery
         raise RuntimeError, "Must pass delivery id, not the delivery itself"
       end
 

--- a/lib/notify_user/channels/gcm/gcm_channel.rb
+++ b/lib/notify_user/channels/gcm/gcm_channel.rb
@@ -7,41 +7,13 @@ class GcmChannel
       }
   	end
 
-    def deliver(notification_id, options={})
-      if notification_id.is_a? NotifyUser::BaseNotification
-        raise RuntimeError, "Must pass notification ids, not the notification itself"
+    def deliver(delivery_id, options={})
+      if delivery_id.is_a? NotifyUser::Delivery
+        raise RuntimeError, "Must pass delivery id, not the delivery itself"
       end
 
-      notification = NotifyUser::BaseNotification.find(notification_id)
-
-      devices = fetch_devices(notification, options[:device_method])
-
-      NotifyUser::Gcm.new([notification], devices, options).push if devices.any?
-    end
-
-    def deliver_aggregated(notification_ids, options={})
-      if notification_ids.first.is_a? NotifyUser::BaseNotification
-        raise RuntimeError, "Must pass notification ids, not the notifications themselves"
-      end
-
-      notifications = NotifyUser::BaseNotification.where(id: notification_ids)
-
-      devices = fetch_devices(notifications.first, options[:device_method])
-
-      NotifyUser::Gcm.new(notifications, devices, options).push if devices.any?
-    end
-
-    private
-
-    def fetch_devices(notification, device_method = nil)
-      device_method ||= :devices
-      devices = notification.target.send(device_method)
-
-      devices.android.to_a
-    rescue
-      [].tap do |devices|
-        Rails.logger.info "Notification target, #{notification.target.class}, does not respond to the method, #{device_method}."
-      end
+      delivery = NotifyUser::Delivery.find(delivery_id)
+      NotifyUser::Gcm.new(delivery, options).push
     end
   end
 end

--- a/spec/lib/notify_user/channels/apns_channel_spec.rb
+++ b/spec/lib/notify_user/channels/apns_channel_spec.rb
@@ -26,7 +26,7 @@ describe ApnsChannel do
     end
   end
 
-  context 'with stubbed Apns push and Notification mobile message' do
+  context 'with stubbed APNS push and Notification mobile message' do
     before :each do
       allow_any_instance_of(NotifyUser::Apns).to receive(:push)
       allow_any_instance_of(TestNotification).to receive(:mobile_message) { 'Notification message' }
@@ -55,9 +55,9 @@ describe ApnsChannel do
         described_class.deliver(delivery.id, {})
       end
 
-      it 'raises an error if the argument is an actual notification object' do
+      it 'raises an error if the argument is an actual delivery object' do
         expect do
-          described_class.deliver(notification)
+          described_class.deliver(delivery)
         end.to raise_error RuntimeError
       end
     end

--- a/spec/lib/notify_user/channels/apns_channel_spec.rb
+++ b/spec/lib/notify_user/channels/apns_channel_spec.rb
@@ -5,32 +5,24 @@ describe ApnsChannel do
 
   let(:user) { User.create({email: 'user@example.com' })}
   let(:notification) { NewPostNotification.create({target: user}) }
+  let(:delivery) { create(:delivery, notification: notification) }
 
-  before do
-    @android = instance_double('Device', token: 'android_token')
-    @ios = instance_double('Device', token: 'ios_token')
-
-    allow(notification).to receive(:mobile_message) { 'Message' }
-
+  before :each do
+    @apns = NotifyUser::Apns.new(delivery, {})
     allow_any_instance_of(NotifyUser::Apns).to receive(:push)
-
-    @devices = double('Device', ios: [@ios], android: [@android])
-    allow_any_instance_of(User).to receive(:devices) { @devices }
-
-    @apns = NotifyUser::Apns.new([notification], [@ios], {})
   end
 
   describe 'device spliting' do
-    it 'routes the notifications via apns' do
+    it 'routes the notifications via APNS' do
       expect(NotifyUser::Apns).to receive(:new) { @apns }
 
-      described_class.deliver(notification.id)
+      described_class.deliver(delivery.id)
     end
 
     it 'doesnt make use of GCM' do
       expect(NotifyUser::Gcm).not_to receive(:new)
 
-      described_class.deliver(notification.id)
+      described_class.deliver(delivery.id)
     end
   end
 
@@ -41,65 +33,31 @@ describe ApnsChannel do
     end
 
     describe '.deliver' do
-      let!(:notification) { TestNotification.create({target: create(:user)}) }
-
       it 'creates an instance of the Apns class' do
         expect(NotifyUser::Apns).to receive(:new)
-          .with([notification], kind_of(Array), kind_of(Hash))
+          .with(delivery, kind_of(Hash))
           .and_call_original
 
-        described_class.deliver(notification.id, {})
+        described_class.deliver(delivery.id, {})
       end
 
       it 'passes on the options' do
         expect(NotifyUser::Apns).to receive(:new)
-          .with([notification], kind_of(Array), hash_including({foo: 'bar'}))
+          .with(delivery, hash_including({foo: 'bar'}))
           .and_call_original
 
-        described_class.deliver(notification.id, {foo: 'bar'})
+        described_class.deliver(delivery.id, { foo: 'bar' })
       end
 
       it 'pushes the notification' do
         expect_any_instance_of(NotifyUser::Apns).to receive(:push)
 
-        described_class.deliver(notification.id, {})
+        described_class.deliver(delivery.id, {})
       end
 
       it 'raises an error if the argument is an actual notification object' do
         expect do
           described_class.deliver(notification)
-        end.to raise_error RuntimeError
-      end
-    end
-
-    describe '.deliver_aggregated' do
-      let!(:notifications) { 3.times.map { TestNotification.create({target: user}) } }
-
-      it 'creates an instance of the Apns class' do
-        expect(NotifyUser::Apns).to receive(:new)
-          .with(notifications, kind_of(Array), kind_of(Hash))
-          .and_call_original
-
-        described_class.deliver_aggregated(notifications.map(&:id), {})
-      end
-
-      it 'passes on the options' do
-        expect(NotifyUser::Apns).to receive(:new)
-          .with(notifications, kind_of(Array), hash_including({foo: 'bar'}))
-          .and_call_original
-
-        described_class.deliver_aggregated(notifications.map(&:id), {foo: 'bar'})
-      end
-
-      it 'pushes the notification' do
-        expect_any_instance_of(NotifyUser::Apns).to receive(:push)
-
-        described_class.deliver_aggregated(notifications.map(&:id), {})
-      end
-
-      it 'raises an error if the argument is actual notification objects' do
-        expect do
-          described_class.deliver_aggregated(notifications)
         end.to raise_error RuntimeError
       end
     end

--- a/spec/lib/notify_user/channels/gcm_channel_spec.rb
+++ b/spec/lib/notify_user/channels/gcm_channel_spec.rb
@@ -5,101 +5,53 @@ describe GcmChannel do
 
   let(:user) { User.create({email: 'user@example.com' })}
   let(:notification) { NewPostNotification.create({target: user}) }
+  let(:delivery) { create(:delivery, notification: notification) }
 
   before do
-    @android = instance_double('Device', token: 'android_token')
-    @ios = instance_double('Device', token: 'ios_token')
-
-    allow(notification).to receive(:mobile_message) { 'Message' }
-
+    @gcm = NotifyUser::Gcm.new(delivery, {})
     allow_any_instance_of(NotifyUser::Gcm).to receive(:push)
-
-    @devices = double('Device', ios: [@ios], android: [@android])
-    allow_any_instance_of(User).to receive(:devices) { @devices }
-
-    @apns = NotifyUser::Gcm.new([notification], [@ios], {})
   end
 
   describe 'device spliting' do
     it 'routes the notifications via gcm' do
-      @gcm = NotifyUser::Gcm.new([notification], [@android], {})
       expect(NotifyUser::Gcm).to receive(:new) { @gcm }
 
-      described_class.deliver(notification.id)
+      described_class.deliver(delivery.id)
     end
 
     it 'doesnt make use of apns' do
       expect(NotifyUser::Apns).not_to receive(:new)
-      described_class.deliver(notification.id)
+      described_class.deliver(delivery.id)
     end
   end
 
-  context 'with stubbed Apns push and Notification mobile message' do
-    before :each do
-      allow_any_instance_of(NotifyUser::Gcm).to receive(:push)
-      allow_any_instance_of(TestNotification).to receive(:mobile_message) { 'Notification message' }
-    end
-
+  context 'with stubbed GCM push and Notification mobile message' do
     describe '.deliver' do
-      let!(:notification) { TestNotification.create({target: create(:user)}) }
-
       it 'creates an instance of the Gcm class' do
         expect(NotifyUser::Gcm).to receive(:new)
-          .with([notification], kind_of(Array), kind_of(Hash))
+          .with(delivery, kind_of(Hash))
           .and_call_original
 
-        described_class.deliver(notification.id, {})
+        described_class.deliver(delivery.id, {})
       end
 
       it 'passes on the options' do
         expect(NotifyUser::Gcm).to receive(:new)
-          .with([notification], kind_of(Array), hash_including({foo: 'bar'}))
+          .with(delivery, hash_including({foo: 'bar'}))
           .and_call_original
 
-        described_class.deliver(notification.id, {foo: 'bar'})
+        described_class.deliver(delivery.id, {foo: 'bar'})
       end
 
       it 'pushes the notification' do
         expect_any_instance_of(NotifyUser::Gcm).to receive(:push)
 
-        described_class.deliver(notification.id, {})
+        described_class.deliver(delivery.id, {})
       end
 
-      it 'raises an error if the argument is an actual notification object' do
+      it 'raises an error if the argument is an actual delivery object' do
         expect do
-          described_class.deliver(notification)
-        end.to raise_error RuntimeError
-      end
-    end
-
-    describe '.deliver_aggregated' do
-      let!(:notifications) { 3.times.map { TestNotification.create({target: user}) } }
-
-      it 'creates an instance of the Apns class' do
-        expect(NotifyUser::Gcm).to receive(:new)
-          .with(notifications, kind_of(Array), kind_of(Hash))
-          .and_call_original
-
-        described_class.deliver_aggregated(notifications.map(&:id), {})
-      end
-
-      it 'passes on the options' do
-        expect(NotifyUser::Gcm).to receive(:new)
-          .with(notifications, kind_of(Array), hash_including({foo: 'bar'}))
-          .and_call_original
-
-        described_class.deliver_aggregated(notifications.map(&:id), {foo: 'bar'})
-      end
-
-      it 'pushes the notification' do
-        expect_any_instance_of(NotifyUser::Gcm).to receive(:push)
-
-        described_class.deliver_aggregated(notifications.map(&:id), {})
-      end
-
-      it 'raises an error if the argument is actual notification objects' do
-        expect do
-          described_class.deliver_aggregated(notifications)
+          described_class.deliver(delivery)
         end.to raise_error RuntimeError
       end
     end

--- a/spec/models/notify_user/apns_spec.rb
+++ b/spec/models/notify_user/apns_spec.rb
@@ -5,17 +5,17 @@ module NotifyUser
   describe Apns do
     let(:user) { create(:user, email: 'user@example.com') }
     let(:notification) { create(:notify_user_notification, params: {}, target: user) }
-
-    describe 'initialisation' do
-      before :each do
-        @apns = Apns.new([notification], [], {})
-      end
-    end
+    let(:delivery) { create(:delivery, notification: notification) }
 
     describe 'push' do
       before :each do
-        @apns = Apns.new([notification], [], {})
+        @apns = Apns.new(delivery, {})
 
+        # Mock device fetching:
+        @device = create_device_double
+        allow(@apns).to receive(:fetch_device) { @device }
+
+        # Mock connection pool:
         @connection = TestAPNConnection.new
         @pool = ConnectionPool.new(size: 1) { @connection }
         stub_const("NotifyUser::APNConnection::POOL", @pool)
@@ -24,34 +24,39 @@ module NotifyUser
       context 'with no errors' do
         before :each do
           @mock_status = instance_double("status", status: "200", body: {})
+          allow(@connection).to receive(:write) { @mock_status }
         end
 
-        it 'succeeds if no error' do
-          expect(@apns.push).to eq true
-        end
-
-        it 'writes to the connection for each device' do
-          devices = []
-          3.times do
-            devices << create_device_double
-          end
-
-          allow(@apns).to receive(:devices) { devices }
-          expect(@connection).to receive(:write).exactly(3).times { @mock_status }
-          @apns.push
+        it 'records the status on the delivery' do
+          expect do
+            @apns.push
+            delivery.reload
+          end.to change(delivery, :status).to '200'
         end
       end
 
       context 'with an error' do
         before :each do
-          @mock_status = instance_double("status", status: "400", body: { "reason" => "BadDeviceToken"})
+          @mock_status = instance_double("status", status: "400", body: { "reason" => "BadDeviceToken" })
           allow(@connection).to receive(:write) { @mock_status }
+          allow(@device).to receive(:destroy)
         end
 
-        it 'destoys the device that failed' do
-          @device = create_device_double
-          allow(@apns).to receive(:devices) { [@device] }
+        it 'records the status on the delivery' do
+          expect do
+            @apns.push
+            delivery.reload
+          end.to change(delivery, :status).to '400'
+        end
 
+        it 'records the reason on the delivery' do
+          expect do
+            @apns.push
+            delivery.reload
+          end.to change(delivery, :reason).to 'BadDeviceToken'
+        end
+
+        it 'removes the bad device' do
           expect(@device).to receive(:destroy) { true }
           @apns.push
         end

--- a/spec/models/notify_user/delivery_generator_spec.rb
+++ b/spec/models/notify_user/delivery_generator_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+module NotifyUser
+  describe DeliveryGenerator do
+    describe '.for' do
+      it 'returns a default generator' do
+        expect(DeliveryGenerator.for('action_mailer').class).to eq DeliveryGenerator
+      end
+
+      it 'returns a apns delivery generator' do
+        expect(DeliveryGenerator.for('apns').class).to eq ApnsDeliveryGenerator
+      end
+
+      it 'returns a gcm delivery generator' do
+        expect(DeliveryGenerator.for('gcm').class).to eq GcmDeliveryGenerator
+      end
+    end
+
+    describe '#generate' do
+      let(:target) { create(:user) }
+      let(:notification) {  NewPostNotification.create({ target: target }) }
+      let(:options) {{ channel: 'action_mailer' , deliver_in: '0', notification: notification }}
+
+      it 'returns a delivery' do
+        generator = DeliveryGenerator.new
+        expect{ generator.generate(notification, options) }.to change(Delivery, :count).by(1)
+      end
+    end
+  end
+
+  describe ApnsDeliveryGenerator do
+    describe '#generate' do
+      let(:target) { create(:user) }
+      let(:notification) {  NewPostNotification.create({ target: target }) }
+      let(:options) {{ channel: 'apns' , deliver_in: '0', notification: notification }}
+
+      it 'creates no delivery if the user has no devices' do
+        generator = ApnsDeliveryGenerator.new
+        allow(generator).to receive(:fetch_devices) { [] }
+
+        expect{ generator.generate(notification, options) }.not_to change(Delivery, :count)
+      end
+
+      it 'creates a delivery if the user has a device' do
+        generator = ApnsDeliveryGenerator.new
+        allow(generator).to receive(:fetch_devices) { ['test'] }
+
+        expect{ generator.generate(notification, options) }.to change(Delivery, :count).by(1)
+      end
+
+      it 'creates multiple deliveries if the user has multiple devices' do
+        generator = ApnsDeliveryGenerator.new
+        allow(generator).to receive(:fetch_devices) { ['test', 'test'] }
+
+        expect{ generator.generate(notification, options) }.to change(Delivery, :count).by(2)
+      end
+    end
+  end
+
+  describe GcmDeliveryGenerator do
+    describe '#generate' do
+      let(:target) { create(:user) }
+      let(:notification) {  NewPostNotification.create({ target: target }) }
+      let(:options) {{ channel: 'apns' , deliver_in: '0', notification: notification }}
+
+      it 'creates no delivery if the user has no devices' do
+        generator = GcmDeliveryGenerator.new
+        allow(generator).to receive(:fetch_devices) { [] }
+
+        expect{ generator.generate(notification, options) }.not_to change(Delivery, :count)
+      end
+
+      it 'creates a delivery if the user has a device' do
+        generator = GcmDeliveryGenerator.new
+        allow(generator).to receive(:fetch_devices) { ['test'] }
+
+        expect{ generator.generate(notification, options) }.to change(Delivery, :count).by(1)
+      end
+
+      it 'creates multiple deliveries if the user has multiple devices' do
+        generator = GcmDeliveryGenerator.new
+        allow(generator).to receive(:fetch_devices) { ['test', 'test'] }
+
+        expect{ generator.generate(notification, options) }.to change(Delivery, :count).by(2)
+      end
+    end
+  end
+end

--- a/spec/models/notify_user/delivery_generator_spec.rb
+++ b/spec/models/notify_user/delivery_generator_spec.rb
@@ -36,21 +36,21 @@ module NotifyUser
 
       it 'creates no delivery if the user has no devices' do
         generator = ApnsDeliveryGenerator.new
-        allow(generator).to receive(:fetch_devices) { [] }
+        allow(generator).to receive(:fetch_device_tokens) { [] }
 
         expect{ generator.generate(notification, options) }.not_to change(Delivery, :count)
       end
 
       it 'creates a delivery if the user has a device' do
         generator = ApnsDeliveryGenerator.new
-        allow(generator).to receive(:fetch_devices) { ['test'] }
+        allow(generator).to receive(:fetch_device_tokens) { ['test'] }
 
         expect{ generator.generate(notification, options) }.to change(Delivery, :count).by(1)
       end
 
       it 'creates multiple deliveries if the user has multiple devices' do
         generator = ApnsDeliveryGenerator.new
-        allow(generator).to receive(:fetch_devices) { ['test', 'test'] }
+        allow(generator).to receive(:fetch_device_tokens) { ['test', 'test'] }
 
         expect{ generator.generate(notification, options) }.to change(Delivery, :count).by(2)
       end
@@ -65,21 +65,21 @@ module NotifyUser
 
       it 'creates no delivery if the user has no devices' do
         generator = GcmDeliveryGenerator.new
-        allow(generator).to receive(:fetch_devices) { [] }
+        allow(generator).to receive(:fetch_device_tokens) { [] }
 
         expect{ generator.generate(notification, options) }.not_to change(Delivery, :count)
       end
 
       it 'creates a delivery if the user has a device' do
         generator = GcmDeliveryGenerator.new
-        allow(generator).to receive(:fetch_devices) { ['test'] }
+        allow(generator).to receive(:fetch_device_tokens) { ['test'] }
 
         expect{ generator.generate(notification, options) }.to change(Delivery, :count).by(1)
       end
 
       it 'creates multiple deliveries if the user has multiple devices' do
         generator = GcmDeliveryGenerator.new
-        allow(generator).to receive(:fetch_devices) { ['test', 'test'] }
+        allow(generator).to receive(:fetch_device_tokens) { ['test', 'test'] }
 
         expect{ generator.generate(notification, options) }.to change(Delivery, :count).by(2)
       end

--- a/spec/workers/notify_user/delivery_worker_spec.rb
+++ b/spec/workers/notify_user/delivery_worker_spec.rb
@@ -6,11 +6,15 @@ RSpec.describe NotifyUser::DeliveryWorker, type: :model do
       described_class.new
     end
 
+    before :each do
+      allow(ApnsChannel).to receive(:deliver)
+    end
+
     it 'performs delivery via the required channel' do
       notification = create(:notify_user_notification)
       delivery = create(:delivery, notification: notification, channel: 'apns')
 
-      expect(ApnsChannel).to receive(:deliver).with(notification.id, anything)
+      expect(ApnsChannel).to receive(:deliver).with(delivery.id, anything)
       subject.perform(delivery.id)
     end
 


### PR DESCRIPTION
Addresses #46 

Adds a generator class for deliveries, that is split between a default generator that just generates a single delivery (for action mailer) and separate generators that pull the list of iOS / Android tokens.

Also works in the logic that @RustComet added in https://github.com/Papercloud/notify_user/tree/feature/delivery-status, so it just tracks a singular delivery response against that delivery, rather than having to track a whole list of applicable device tokens.

Something that came up I still need to look into is decoupling everything from Dre, the generator classes know too much about how it specifically works to be useful.